### PR TITLE
Permute a vector by flipping the order of modes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SphericalHarmonicArrays"
 uuid = "9dd28c12-4719-4e7d-b634-e7b733a6d046"
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/SphericalHarmonicArrays.jl
+++ b/src/SphericalHarmonicArrays.jl
@@ -581,9 +581,8 @@ Permute `v` with the map obtained by flipping the order of modes in `p`.
 function permuteflipmodes(v::AbstractVector, modes::Union{LM,ML})
     modes_new = SphericalHarmonicModes.flip(modes)
     v_new = SHArray(similar(v), modes_new)
-    v_sh = SHArray(v, modes)
-    @inbounds for m in modes
-        v_new[m] = v[m]
+    @inbounds for (ind, m) in enumerate(modes)
+        v_new[m] = v[ind]
     end
     return v_new
 end

--- a/src/SphericalHarmonicArrays.jl
+++ b/src/SphericalHarmonicArrays.jl
@@ -586,6 +586,6 @@ function permuteflipmodes(v::AbstractVector, modes::Union{LM,ML})
     end
     return v_new
 end
-permuteflipmodes(v::SHVector) = permuteflipmodes(v, only(modes(v)))
+permuteflipmodes(v::SHVector) = permuteflipmodes(v, first(modes(v)))
 
 end # module

--- a/src/SphericalHarmonicArrays.jl
+++ b/src/SphericalHarmonicArrays.jl
@@ -573,4 +573,20 @@ function Base.replace_in_print_matrix(A::SHArray, i::Integer, j::Integer, s::Abs
     Base.replace_in_print_matrix(parent(A), i, j, s)
 end
 
+"""
+    permuteflipmodes(v::AbstractVector, p::Union{LM, ML})
+
+Permute `v` with the map obtained by flipping the order of modes in `p`.
+"""
+function permuteflipmodes(v::AbstractVector, modes::Union{LM,ML})
+    modes_new = SphericalHarmonicModes.flip(modes)
+    v_new = SHArray(similar(v), modes_new)
+    v_sh = SHArray(v, modes)
+    @inbounds for m in modes
+        v_new[m] = v[m]
+    end
+    return v_new
+end
+permuteflipmodes(v::SHVector) = permuteflipmodes(v, only(modes(v)))
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -914,12 +914,14 @@ end
     modes = LM(0:lmax);
     v = SHArray(1:length(modes), modes)
     v2 = SphericalHarmonicArrays.permuteflipmodes(v)
-    @test parent(v2) == [4,2,5,7,1,3,6,8,9]
+    p = modeindex.((modes,), SphericalHarmonicModes.flip(modes))
+    @test parent(v2) == v[p]
 
     modes = ML(0:lmax);
     v = SHArray(1:length(modes), modes)
     v2 = SphericalHarmonicArrays.permuteflipmodes(v)
-    @test parent(v2) == [5,2,6,1,3,7,4,8,9]
+    p = modeindex.((modes,), SphericalHarmonicModes.flip(modes))
+    @test parent(v2) == v[p]
 end
 
 @testset "show" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -909,6 +909,19 @@ end
     end
 end
 
+@testset "permuteflipmodes" begin
+    lmax = 2;
+    modes = LM(0:lmax);
+    v = SHArray(1:length(modes), modes)
+    v2 = SphericalHarmonicArrays.permuteflipmodes(v)
+    @test parent(v2) == [4,2,5,7,1,3,6,8,9]
+
+    modes = ML(0:lmax);
+    v = SHArray(1:length(modes), modes)
+    v2 = SphericalHarmonicArrays.permuteflipmodes(v)
+    @test parent(v2) == [5,2,6,1,3,7,4,8,9]
+end
+
 @testset "show" begin
     io = IOBuffer()
     showerror(io, SphericalHarmonicArrays.ModeMismatchError(LM(1:2), LM(1:4)))


### PR DESCRIPTION
```julia
julia> lmax = 2; modes = LM(0:lmax); v = SHArray(1:length(modes), modes)
9-element SHArray(::UnitRange{Int64}, (LM(0:2, -2:2),)):
 1
 2
 3
 4
 5
 6
 7
 8
 9

julia> SphericalHarmonicArrays.permuteflipmodes(v)
9-element SHArray(::Vector{Int64}, (ML(0:2, -2:2),)):
 4
 2
 5
 7
 1
 3
 6
 8
 9
```

This is equivalent to 

```julia
julia> p = modeindex.((modes,), SphericalHarmonicModes.flip(modes));

julia> v[p]
9-element Vector{Int64}:
 4
 2
 5
 7
 1
 3
 6
 8
 9
```

however the function in this package is more efficient as the permutation vector does not need to be generated explicitly.